### PR TITLE
Automatically switch frames, avoid frames with errors, region threshold

### DIFF
--- a/dot_detection.py
+++ b/dot_detection.py
@@ -1,6 +1,8 @@
 import cv2
 
 
+REGION_MIN_SIZE = 70
+
 def dfs(img, x, y, label, region_stats):
     img[y, x] = label + 1
     region_stats[label]['x_sum'] += x
@@ -35,6 +37,10 @@ def connected_components(img):
                 x_mean = int(region_stats[label]['x_sum'] / region_stats[label]['count'])
                 y_mean = int(region_stats[label]['y_sum'] / region_stats[label]['count'])
                 region_stats[label]['center'] = (x_mean, y_mean)
+                if region_stats[label]['count'] < REGION_MIN_SIZE: #remove small regions
+                    del region_stats[label]
+                else:
+                    print(f"region size: {region_stats[label]['count']}")
     return label, region_stats
 
 

--- a/dot_detection.py
+++ b/dot_detection.py
@@ -39,8 +39,6 @@ def connected_components(img):
                 region_stats[label]['center'] = (x_mean, y_mean)
                 if region_stats[label]['count'] < REGION_MIN_SIZE: #remove small regions
                     del region_stats[label]
-                else:
-                    print(f"region size: {region_stats[label]['count']}")
     return label, region_stats
 
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import cv2
 from processing import read_video, clean_dice_video_seq
 from dot_detection import detect_face
@@ -23,14 +25,19 @@ if __name__ == '__main__':
         bEnd = (int(b[0]) + 33, int(b[1]) + 33)
         firstDie = frame_bgr[aStart[1]:aEnd[1], aStart[0]:aEnd[0]]
         secondDie = frame_bgr[bStart[1]:bEnd[1], bStart[0]:bEnd[0]]
-        numOnFirstDice, throwAway1 = detect_face(firstDie)
-        numOnSecondDice, throwAway2 = detect_face(secondDie)
+        try:
+            numOnFirstDice, throwAway1 = detect_face(firstDie)
+            numOnSecondDice, throwAway2 = detect_face(secondDie)
+        except: #if error, skip frame
+            continue
         # Add the rectangles and text to the image, display it
         cv2.rectangle(im_seq_bgr[i], aStart, aEnd, (0, 0, 0), 2)
         cv2.rectangle(im_seq_bgr[i], bStart, bEnd, (0, 0, 0), 2)
         cv2.putText(im_seq_bgr[i], str(numOnFirstDice), aStart, cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 0), 2)
         cv2.putText(im_seq_bgr[i], str(numOnSecondDice), bStart, cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 0), 2)
-        cv2.namedWindow(f'frame: {i}, dots in frame: {num_dots}')
-        cv2.imshow(f'frame: {i}, dots in frame: {num_dots}', im_seq_bgr[i])
-        cv2.waitKey(0)
-        cv2.destroyWindow(f'frame {i}')
+        window_name = f'frame: {i}, dots in frame: {num_dots}'
+        cv2.namedWindow(window_name)
+        cv2.imshow(window_name, im_seq_bgr[i])
+        cv2.setWindowProperty(window_name, cv2.WND_PROP_TOPMOST, 1)
+        cv2.waitKey(1)
+        #cv2.destroyWindow(f'frame {i}')


### PR DESCRIPTION
- Automatically go to next frame after 1 second.
- Set window to be on top (so you see it right away when running)
- Set min threshold for dot regions to avoid any noise
- Use try/except to avoid frames that are causing errors (I suspect this is because it was trying to get patches that were off-screen, but not sure)